### PR TITLE
startsWith - it's not a universal

### DIFF
--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -64,7 +64,7 @@ export function getFolderName(path: string): string {
  */
 export function startsWithOne(str: string, prefixes: string[]): boolean {
   for (let p of prefixes) {
-    if (str.startsWith(p))
+    if (str.substr(0,p.length) === p)
       return true;
   }
   return false;


### PR DESCRIPTION
`startsWith` not supported not-latin symbols, because use RegExp key: \b, after compile to native js