### PR TITLE
universal marker search

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Contains the words that signal the start of TODOs. For example, `"markers": ["NO
 
 
 #### autoDefaultMarkers
-If `true`, automatically add the default markers: "TODO", "Todo", and "todo". Default is `true`.
+If `true`, automatically add the default "TODO" marker. Default is `true`.
 
 
 ## Supported languages

--- a/src/classes/UserSettings.ts
+++ b/src/classes/UserSettings.ts
@@ -110,7 +110,7 @@ export class UserSettings {
     }
 
     if(this.AutoAddDefaultMarkers.getValue()) {
-      this.Markers.setValue(this.Markers.getValue().concat(['TODO:', 'Todo:', 'todo:']));
+      this.Markers.setValue(this.Markers.getValue().concat(['TODO']));
     }
   }
 }

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -64,7 +64,11 @@ export function getFolderName(path: string): string {
  */
 export function startsWithOne(str: string, prefixes: string[]): boolean {
   for (let p of prefixes) {
-    if (str.startsWith(p))
+    if (/\w/.test(p[0]))
+      p = '\\b' + p;
+    if (/\w/.test(p.slice(-1)))
+      p = p + '\\b';
+    if ((new RegExp(p, 'i')).test(str))
       return true;
   }
   return false;


### PR DESCRIPTION
### Make universal marker search
Fixed issues:
1. Do not support Chinese ? https://github.com/kantlove/vscode-todo-parser/issues/44
2. TODO after commenting a line of code does not work https://github.com/kantlove/vscode-todo-parser/issues/36

example for default settings:
```
// TODO: basic

// return 0 ; // Todo: in midle

// TODO - more todo

// Todo:more

// todo: and more

// TODO не латинский, в том числе issue#44

// TODO - фоо

// TODO: this todo is valid

/* TODO: this is also ok */

/* It's a nice day today
 *
 * Todo: multi-line TODOs are
 * supported too!
 */
```