### PR TITLE
Integration with Problems Panel (Resolves #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Include the below snippet in your __User Settings__ (File > Preferences > User S
   "include": ["js"],
   "folderExclude": ["node_modules", ".vscode"],
   "only": ["sub-folder/sub-sub-folder"],
-  "markers": ["NOTE:", "REMINDER:"],
+  "showInProblems": false,
+  "markers": ["NOTE:", "REMINDER:", ["FIXME", "Warning"]],
   "autoDefaultMarkers": true
 }
 ```
@@ -91,8 +92,23 @@ root
 }
 ```
 
+#### showInProblems
+If `true`, show the results in the Problems panel instead of the Output panel.
+
 #### markers
-Contains the words that signal the start of TODOs. For example, `"markers": ["NOTE:"]` will enable matching `NOTE: this is a new type of TODO`.
+Contains the words that signal the start of TODOs. It can contain either strings, or tuples of [marker string, priority] pairs.
+
+Priority can be either of these strings (sorted by severity, lowest to highest):
+
+* `"Hint"`
+* `"Information"`
+* `"Warning"`
+* `"Error"`
+
+Example usage:
+
+* `"markers": ["NOTE:"]` will enable matching `NOTE: this is a new type of TODO`.
+* `"markers": [ ["FIXME:", "Warning"] ]` will enable matching `FIXME: This is important` and will mark it as a warning in the Problems panel.
 
 
 #### autoDefaultMarkers

--- a/package.json
+++ b/package.json
@@ -45,7 +45,13 @@
       "properties": {
         "TodoParser": {
           "type": "object",
-          "description": "Configurations for the extension."
+          "description": "Configurations for the extension.",
+          "properties": {
+            "showInProblems": {
+              "type": "boolean",
+              "description": "If true, show TODO comments in Problems panel."
+            }
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,29 @@
           "type": "object",
           "description": "Configurations for the extension.",
           "properties": {
+            "markers": {
+              "type": "array",
+              "description": "An array of words that signal the start of TODOs, or tuples containig the words and their priorities.",
+              "items": {
+                "type": ["string", "array"],
+                "description": "Word that signals the start of a TODO comment, or a tuple of the word and comment priority.",
+                "items": [
+                  {
+                    "type": "string",
+                    "description": "Word that signals the start of a TODO comment."
+                  },
+                  {
+                    "enum": [
+                      "Error", 0,
+                      "Warning", 1,
+                      "Information", 2,
+                      "Hint", 3
+                    ],
+                    "description": "The priority level of the TODO comment. Determines how the TODO item is rendered in the Problems panel"
+                  }
+                ]
+              }
+            },
             "showInProblems": {
               "type": "boolean",
               "description": "If true, show TODO comments in Problems panel."

--- a/src/classes/OutputWriter.ts
+++ b/src/classes/OutputWriter.ts
@@ -1,4 +1,4 @@
-import {window, languages, OutputChannel, Diagnostic, DiagnosticSeverity, Range, StatusBarItem, StatusBarAlignment} from 'vscode';
+import {window, languages, OutputChannel, Diagnostic, Range, StatusBarItem, StatusBarAlignment} from 'vscode';
 import {UserSettings} from './UserSettings';
 import {TodoType} from '../types/all';
 import {CHANNEL_NAME} from '../const/all';
@@ -57,7 +57,6 @@ export class OutputWriter {
    * when writing is done.
    * @param todos List of todos to be written to the panel.
    */
-  // TODO: Just a test
   static writeTodo(todos: TodoType[]) {
     assert(OutputWriter.state === State.Begin || OutputWriter.state === State.Busy, "begin() is not called.");
     OutputWriter.state = State.Busy;    
@@ -80,8 +79,7 @@ export class OutputWriter {
           diags.push(new Diagnostic(
             new Range(todo.getLineNumber() - 1, 0, todo.getLineNumber() - 1, Number.MAX_VALUE), 
             todo.getContent(), 
-            // TODO: determineSeverity() -> severity[marker] dict
-            DiagnosticSeverity.Hint
+            todo.getSeverity()
           ));
 
           diagnostics.set(fileUri, diags);

--- a/src/classes/OutputWriter.ts
+++ b/src/classes/OutputWriter.ts
@@ -50,6 +50,11 @@ export class OutputWriter {
     }
 
     OutputWriter.state = State.Idle;
+
+    // TODO: We should show the Problems panel here, if the 'showInProblems' setting is set to true,
+    // but VS Code Extension API currently doesn't allow us to do that. However, this feature is
+    // coming in one of the upcoming updates. 
+    // See issue for details: https://github.com/Microsoft/vscode/issues/11399.
   }
 
   /**

--- a/src/classes/UserSettings.ts
+++ b/src/classes/UserSettings.ts
@@ -185,6 +185,9 @@ export class MarkersSettingEntry extends SetSettingEntry<string[]> {
   setValue(value: MarkerType): boolean {
     this.priorities = {};
 
+    // If value is undefined or null, make our lives easier and set it to an empty array
+    if(!value) { value = []; }
+
     // Go through each settings item to build a dictionary of (marker, priority) pairs.
     for (let item of value) {
       if (item instanceof Array) {

--- a/src/classes/UserSettings.ts
+++ b/src/classes/UserSettings.ts
@@ -24,6 +24,9 @@ export class UserSettings {
   // Whether default markers (e.g. todo, TODO) are added automatically
   AutoAddDefaultMarkers = new ToggleSettingEntry("autoDefaultMarkers", true);
 
+  // Show in problems panel?
+  ShowInProblems = new ToggleSettingEntry("showInProblems", false);
+
   // Turn on/off dev mode
   DevMode = new ToggleSettingEntry("devMode", false);
 
@@ -45,7 +48,7 @@ export class UserSettings {
    */
   reload() {
     let settings = workspace.getConfiguration(this.SETTING_ROOT_ENTRY);
-    let toLoad = [this.Exclusions, this.Inclusions, this.Markers, this.FolderExclusions, this.Only, this.AutoAddDefaultMarkers, this.DevMode];
+    let toLoad = [this.Exclusions, this.Inclusions, this.Markers, this.FolderExclusions, this.Only, this.AutoAddDefaultMarkers, this.ShowInProblems, this.DevMode];
 
     if (settings) {
       for (let st of toLoad) {

--- a/src/types/TodoType.ts
+++ b/src/types/TodoType.ts
@@ -1,16 +1,19 @@
 import {FileType} from './FileType';
 import {languages, Uri} from 'vscode';
 import {SCHEME} from '../const/all'
+import {UserSettings} from '../classes/UserSettings';
 
 export class TodoType {
   content: string;
   private lineNumber: number;
   private file: FileType;
+  private marker: string;
 
-  constructor(file: FileType, content: string, line = 0) {
+  constructor(file: FileType, content: string, line = 0, marker = "TODO") {
     this.file = file;
     this.content = content;
     this.lineNumber = line;
+    this.marker = marker;
   }
 
   getContent(): string {
@@ -23,6 +26,14 @@ export class TodoType {
 
   getFile(): FileType {
     return this.file;
+  }
+
+  getType(): string {
+    return this.marker;
+  }
+
+  getSeverity(): number {
+    return UserSettings.getInstance().Markers.getPriorityOf(this.marker);
   }
 
   getDisplayString(): string {

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -61,15 +61,16 @@ export function getFolderName(path: string): string {
  * prefixes and false otherwise.
  * @param str       String to be checked.
  * @param prefixes  A list of prefixes.
+ * @returns {[boolean, string]}  A tuple of whether a match is found (boolean) and the matched prefix.
  */
-export function startsWithOne(str: string, prefixes: string[]): boolean {
+export function startsWithOne(str: string, prefixes: string[]): [boolean, string] {
   for (let p of prefixes) {
     if (/\w/.test(p[0]))
       p = '\\b' + p;
     if (/\w/.test(p.slice(-1)))
       p = p + '\\b';
     if ((new RegExp('^' + p, 'i')).test(str))
-      return true;
+      return [true, p.replace(/\\b/g, '')];
   }
-  return false;
+  return [false, null];
 }


### PR DESCRIPTION
I implemented support for rendering TODO comments in the Problems panel instead of the Output panel.

Displaying tasks in the problem panel is optional and happens only if the (new) `showInProblems` setting is set to true.

Furthermore, I expanded the `markers` setting, so that it now accepts a list of strings or tuples. Tuples are pairs of *marker string* and *priority level*. Priority level is used to display the appropriate icon (warning, error, info) in the Problems panel. Accepted values are:

* "Error"
* "Warning"
* "Information"
* "Hint"

  and a numeric range `0-3`, with meanings respective to the list above.

I've also added schema definitions for these two settings (`showInProblems` and `markers`), so that VS Code can validate the user's settings.

Please let me know if you have any questions or comments.