### PR TITLE
Don't reject whole batch of files because some of them failed to load…

### DIFF
--- a/src/types/CommandType.ts
+++ b/src/types/CommandType.ts
@@ -45,7 +45,7 @@ export class ParseAllFilesCommand implements CommandType {
       let results = [], errors = [];
       FileReader.readProjectFiles(
         (files: FileType[], progress, error) => {
-          if (!error) {
+          if (files.length > 0) {
             files = FileFilter.filter(files);
             let todos = Parser.parse(files);
             results = results.concat(todos);
@@ -53,7 +53,9 @@ export class ParseAllFilesCommand implements CommandType {
             StatusBarManager.getInstance().setWorking(`${WORKING_ICON} ${progress}%`, "Click to cancel");
             totalFiles += todos.length;
           }
-          else {
+          // We could have files available, but still have an error
+          // because some of them failed to load.
+          if (error) {
             errors.push(error);
           }
         },


### PR DESCRIPTION
…. Fixes "Parse All Files" (issue #54).

As I mentioned in #54, when `FileReader.readFileFromNames()` failes to read any single file within a batch, it would reject it's Promise, spawning an error which led to valid files being discarded and `OutputWriter` having inconsistent state. This commit fixes that.

This does not fix the `OutputWriter` state management issues directly. They should still be dealt with in another patch.

While "Parse All Files" now works correctly, there is an issue with VS code that will make it spawn "Uncaught exception" errors whenever `workspace.openTextDocument()` fails to open a file. See https://github.com/Microsoft/vscode/issues/27809 and https://github.com/Microsoft/vscode/pull/28069 for details.