### PR TITLE
Fix: Cmd+Click can jump to file

### DIFF
--- a/src/types/TodoType.ts
+++ b/src/types/TodoType.ts
@@ -39,7 +39,7 @@ export class TodoType {
   getDisplayString(): string {
     let url = this.getFile().getFile().uri.toString();
     // to take it to the properline
-    let middle = "#";
+    let middle = " #";
     // what if the file is not saved?
     if (url.split(":")[0].toString() == "untitled") {
         middle = "; Line Number: ";


### PR DESCRIPTION
now when you click on the path:
<img width="260" alt="image" src="https://user-images.githubusercontent.com/71683364/196595815-d27a822d-9163-4f49-8177-5e8c57048605.png">

add a space may help